### PR TITLE
Add basic management interface

### DIFF
--- a/frontEnd/src/app/app-routing.module.ts
+++ b/frontEnd/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { EntornoComponent } from './components/entorno/entorno.component';
 import { LoginComponent } from './components/login/login.component';
 import { OrdenVisualComponent } from './components/orden-visual/orden-visual.component';
 import { HistorialComponent } from './components/historial/historial.component';
+import { GestionComponent } from './components/gestion/gestion.component';
 import { LoginGuard } from '../service/guards/login.guard'; 
 
 export const routes: Routes = [
@@ -26,6 +27,11 @@ export const routes: Routes = [
   {
     path: 'historial',
     component: HistorialComponent,
+    canActivate: [LoginGuard]
+  },
+  {
+    path: 'gestion',
+    component: GestionComponent,
     canActivate: [LoginGuard]
   },
 ];

--- a/frontEnd/src/app/app.module.ts
+++ b/frontEnd/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { OrdenVisualComponent } from './components/orden-visual/orden-visual.com
 import { HistorialComponent } from './components/historial/historial.component';
 import { HttpClientModule } from '@angular/common/http';
 import { ProtectedComponent } from './components/ProtectedComponent';
+import { GestionComponent } from './components/gestion/gestion.component';
 
 
 @NgModule({
@@ -21,6 +22,7 @@ import { ProtectedComponent } from './components/ProtectedComponent';
     OrdenVisualComponent,
     HistorialComponent,
     ProtectedComponent,
+    GestionComponent,
    
   ],
   imports: [

--- a/frontEnd/src/app/components/entorno/entorno.component.html
+++ b/frontEnd/src/app/components/entorno/entorno.component.html
@@ -23,8 +23,8 @@
               Historial
             </a>
           </li>
-          <li class="FlexLista">
-            <a  class="txtNav " href="/ot">
+          <li class="FlexLista" *ngIf="isAdmin">
+            <a  class="txtNav " href="/gestion">
               Gestion
             </a>
           </li>

--- a/frontEnd/src/app/components/gestion/gestion.component.ts
+++ b/frontEnd/src/app/components/gestion/gestion.component.ts
@@ -1,0 +1,94 @@
+import { Component, OnInit } from '@angular/core';
+import { OtServiceService } from '../../../service/ot-service.service';
+import { Usuario } from '../../interfaces/usuario';
+import { Piso } from '../../interfaces/piso';
+
+@Component({
+  selector: 'app-gestion',
+  template: `
+    <div class="gestion-container">
+      <h2>Operarios</h2>
+      <div class="add-form">
+        <input [(ngModel)]="nuevoUsuario.nombre" placeholder="Nombre">
+        <input [(ngModel)]="nuevoUsuario.mail" placeholder="Mail">
+        <input [(ngModel)]="nuevoUsuario['contraseña']" placeholder="Contraseña">
+        <button (click)="addUsuario()">Agregar</button>
+      </div>
+      <ul>
+        <li *ngFor="let u of usuarios">
+          <input [(ngModel)]="u.nombre">
+          <button (click)="updateUsuario(u)">Guardar</button>
+          <button (click)="deleteUsuario(u.id_usuarios)">Eliminar</button>
+        </li>
+      </ul>
+
+      <h2>Pisos</h2>
+      <div class="add-form">
+        <input [(ngModel)]="nuevoPiso" placeholder="Nombre">
+        <button (click)="addPiso()">Agregar</button>
+      </div>
+      <ul>
+        <li *ngFor="let p of pisos">
+          <input [(ngModel)]="p.nombre">
+          <button (click)="updatePiso(p)">Guardar</button>
+          <button (click)="deletePiso(p.id_piso)">Eliminar</button>
+        </li>
+      </ul>
+    </div>
+  `,
+  styles: `
+    .gestion-container{padding:1rem;}
+    .add-form input{margin-right:0.5rem;}
+    ul{list-style:none;padding:0;}
+    li{margin-bottom:0.5rem;}
+  `
+})
+export class GestionComponent implements OnInit {
+  usuarios: Usuario[] = [];
+  pisos: Piso[] = [];
+  nuevoUsuario: Partial<Usuario> = {};
+  nuevoPiso: string = '';
+
+  constructor(private api: OtServiceService) {}
+
+  ngOnInit(): void {
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.api.getUser('').subscribe(d => this.usuarios = Array.isArray(d) ? d : [d]);
+    this.api.getPiso('').subscribe(d => this.pisos = Array.isArray(d) ? d : [d]);
+  }
+
+  addUsuario(): void {
+    if (!this.nuevoUsuario.nombre || !this.nuevoUsuario.mail || !this.nuevoUsuario['contraseña']) return;
+    this.api.createUsuario(this.nuevoUsuario).subscribe(() => {
+      this.nuevoUsuario = {};
+      this.loadData();
+    });
+  }
+
+  updateUsuario(u: Usuario): void {
+    this.api.updateUsuario(u.id_usuarios, u.nombre).subscribe(() => this.loadData());
+  }
+
+  deleteUsuario(id: number): void {
+    this.api.deleteUsuario(id).subscribe(() => this.loadData());
+  }
+
+  addPiso(): void {
+    if (!this.nuevoPiso) return;
+    this.api.createPiso(this.nuevoPiso).subscribe(() => {
+      this.nuevoPiso = '';
+      this.loadData();
+    });
+  }
+
+  updatePiso(p: Piso): void {
+    this.api.updatePiso(p.id_piso, p.nombre).subscribe(() => this.loadData());
+  }
+
+  deletePiso(id: number): void {
+    this.api.deletePiso(id).subscribe(() => this.loadData());
+  }
+}

--- a/frontEnd/src/service/ot-service.service.ts
+++ b/frontEnd/src/service/ot-service.service.ts
@@ -76,7 +76,32 @@ export class OtServiceService {
   }
 
   deleteOT(id: number): Observable<any> {
-    return this.http.delete(`${this.apiUrl}/ot/delete${id}`); 
+    return this.http.delete(`${this.apiUrl}/ot/delete${id}`);
+  }
+
+  // Gestion APIs
+  createPiso(nombre: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/piso/create`, { nombre });
+  }
+
+  updatePiso(id: number, nombre: string): Observable<any> {
+    return this.http.put(`${this.apiUrl}/piso/edit${id}`, { nombre });
+  }
+
+  deletePiso(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/piso/delete${id}`);
+  }
+
+  createUsuario(userData: any): Observable<any> {
+    return this.http.post(`${this.apiUrl}/usuario/`, userData);
+  }
+
+  updateUsuario(id: number, nombre: string): Observable<any> {
+    return this.http.put(`${this.apiUrl}/usuario`, { id, nombre });
+  }
+
+  deleteUsuario(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/usuario/${id}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- add new GestionComponent for admin management
- wire up /gestion route and display link in sidebar
- extend OT service with piso & usuario CRUD calls

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6848313781f0832ab15ce47a2ae2dc2c