### PR TITLE
Replace login background image with gradient

### DIFF
--- a/frontEnd/src/app/components/login/login.component.css
+++ b/frontEnd/src/app/components/login/login.component.css
@@ -1,7 +1,8 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 body {
   font-family: 'Segoe UI', sans-serif;
-  background-color: #0d2c4a;
+  /* Replaced heavy background image with a CSS gradient */
+  background: linear-gradient(135deg, #0d2c4a, #1f6cb0);
   color: #fff;
 }
 
@@ -12,7 +13,8 @@ body {
   align-items: center;
   justify-content: center;
   height: 100vh;
-  background-color: #0d2c4a; 
+  /* Match gradient background */
+  background: linear-gradient(135deg, #0d2c4a, #1f6cb0);
 }
 
 .toggle { display: none; }


### PR DESCRIPTION
## Summary
- replace heavy login background image with a CSS gradient

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b9db475c832aa8e778b154e62c82