### PR TITLE
Fix OT deletion in history table

### DIFF
--- a/frontEnd/src/app/components/historial/historial.component.ts
+++ b/frontEnd/src/app/components/historial/historial.component.ts
@@ -241,11 +241,10 @@ export class HistorialComponent implements OnInit {
     confirmButton.onclick = () => {
       this.otService.deleteOT(id).subscribe({
         next: () => {
-          this.otService.getOT().subscribe((ots: any[]) => {
-            this.ots = ots;
-            this.extractUniqueValues();
-            this.mostrarTablaFiltrada();
-          });
+          // Actualiza la lista local eliminando la OT sin necesidad de recargar
+          this.ots = this.ots.filter(ot => ot.id !== id);
+          this.extractUniqueValues();
+          this.mostrarTablaFiltrada();
           document.body.removeChild(modal);
         },
         error: (error) => {


### PR DESCRIPTION
## Summary
- refresh OT list locally after deletion so removed OTs disappear from the table

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6849c7e4097c832aa45824b4e838ff52